### PR TITLE
add prodcuts controllers for new pages

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,0 +1,7 @@
+class ProductsController < ApplicationController
+  def careteam
+  end
+
+  def carelink
+  end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,9 +13,15 @@
             </div>
             <div id="navbar" class="navbar-collapse collapse">
               <ul class="nav navbar-nav navbar-right">
-                <li class="active"><a href="#top">Home</a></li>
-                <li class="active"><a href="#CareTEAM">CareTEAM</a></li>
-                <li class="active"><a href="#CareLINK">CareLINK</a></li>
+                <li class="active">
+                  <%=link_to 'Home', static_pages_home_path%>
+                </li>
+                <li class = "active">
+                  <%=link_to 'CareTEAM', products_careteam_path%>
+                </li>
+                <li class="active">
+                  <%=link_to 'CareLINK', products_carelink_path%>
+                </li>
                 <li class="active"><a href="#">Contact Us</a></li>
               </ul>
             </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,5 +17,11 @@
     <%= csrf_meta_tags %>
     <%= render 'layouts/shim' %>
   </head>
+  <% provide(:title, "Home") %>
+  <body data-spy="scroll" data-target=".navbar">
+    <%= render 'layouts/header' %>
+  </body>
+</div>
   <%= yield %>
+  <%= render 'layouts/footer' %>
 </html>

--- a/app/views/products/carelink.html.erb
+++ b/app/views/products/carelink.html.erb
@@ -1,0 +1,22 @@
+    <span class="anchor" id="CareLINK"></span>
+      <hr class = "topicbreak">
+        <div class="row featurette">
+        <%= image_tag("careLINK-logo.png", alt: "careLINK-logo", class: "img-responsive center-block") %>
+        <div class="col-md-6">
+          <%= image_tag("CareLINKList.png", alt: "CareLINKList", class: "img-responsive center-block") %>
+        </div>
+        <div class="col-md-3">
+          <%= image_tag("DoctorWhite.png", alt: "DoctorWhite", class: "img-responsive center-block") %>
+        </div>
+        <div class="col-md-3">
+          <%= image_tag("PatientWhite.png", alt: "PatientWhite", class: "img-responsive center-block") %>
+        </div>
+      </div>
+      <hr>
+      <div class="row featurette">
+        <div class="col-md-5">
+          <%= image_tag("iMac2.png", alt: "iMac", class: "img-responsive center-block") %>
+        </div>
+        <div class="col-md-7">
+          <%= image_tag("CareLINKComparison.png", alt: "CareLINKComparison", class: "img-responsive center-block") %>
+        </div>

--- a/app/views/products/careteam.html.erb
+++ b/app/views/products/careteam.html.erb
@@ -1,0 +1,23 @@
+    <span class="anchor" id="CareTEAM"></span>
+      <hr class = "topicbreak">
+      <div class="row featurette">
+        <%= image_tag("careTeam-logo.png", alt: "careTEAM-logo", class: "img-responsive center-block") %>
+        <div class="col-md-6">
+          <%= image_tag("CareLINKList.png", alt: "CareLINKList", class: "img-responsive center-block") %>
+        </div>
+        <div class="col-md-3">
+          <%= image_tag("DoctorWhite.png", alt: "DoctorWhite", class: "img-responsive center-block") %>
+        </div>
+        <div class="col-md-3">
+          <%= image_tag("PatientWhite.png", alt: "PatientWhite", class: "img-responsive center-block") %>
+        </div>
+      </div>
+      <hr>
+      <div class="row featurette">
+        <div class="col-md-5">
+          <%= image_tag("iMac2.png", alt: "iMac", class: "img-responsive center-block") %>
+        </div>
+        <div class="col-md-7">
+          <%= image_tag("CareTEAMComparison.png", alt: "CareTEAMComparison", class: "img-responsive center-block") %>
+        </div>
+      </div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -2,10 +2,5 @@
   <body data-spy="scroll" data-target=".navbar">
     <%= render 'layouts/header' %>
     <%= render 'layouts/carousel' %>
-    <div class="container">
-      <%= render 'layouts/careTEAM' %>
-      <%= render 'layouts/careLINK' %>
-    </div>
   </body>
-  <%= render 'layouts/footer' %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,10 @@ Rails.application.routes.draw do
   get 'static_pages/help'
   get 'static_pages/about'
 
+  #Products
+  get 'products/careteam' => 'products#careteam'
+  get 'products/carelink' => 'products#carelink'
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 


### PR DESCRIPTION
This creates a new products controllers which hold the paths for carelink and careteam.

I also moved the shared css between pages to application.html.erb (i.e. the header and the footer will be shared across all pages)

I moved your html for the carlink and careteam products into their own views which rails nows to render.
If we hit app/controllers/products/carelink, it knows to render the view in app/views/products/carelink.html.erb

I also added the new routes to the routes.rb file